### PR TITLE
Access named regex groups directly on event parse

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -136,11 +136,11 @@ class Event(object):
                 warnings.warn('Invalid SSE line: "%s"' % line, SyntaxWarning)
                 continue
 
-            name = m.groupdict()['name']
-            value = m.groupdict()['value']
+            name = m.group('name')
             if name == '':
                 # line began with a ":", so is a comment.  Ignore
                 continue
+            value = m.group('value')
 
             if name == 'data':
                 # If we already have some data, then join to it with a newline.


### PR DESCRIPTION
Gives a ~25% speedup for e.g.

```
$ python -m timeit -s \
    "from sseclient import Event; data = 'event: x\ndata: y\n'" \
    "Event.parse(data)"
```

While at it, don't access the group if it's going to be ignored.