### PR TITLE
Improve performance by using iter_content and iterating

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -62,7 +62,7 @@ class SSEClient(object):
             self.resp.encoding)(errors='replace')
         while not self._event_complete():
             try:
-                next_chunk = self.resp_iterator.next()
+                next_chunk = next(self.resp_iterator)
                 if not next_chunk:
                     raise EOFError()
                 self.buf += decoder.decode(next_chunk)

--- a/test_sseclient.py
+++ b/test_sseclient.py
@@ -77,6 +77,8 @@ class FakeResponse(object):
     def raise_for_status(self):
         pass
 
+    def iter_content(self, chunk_size=1024):
+        return self.raw
 
 def join_events(*events):
     """


### PR DESCRIPTION
Improve performance by using iter_content and iterating, rather than reading bytes directly

Currently this library attempts to access the response.raw object,
which is ultimately a urllib3 response iterator. I'm not totally
sure why, but in a streaming context, treating raw as a file like
object and using readlines (or reading 1 byte at a time, which an
older version of this sseclient library did), is CPU intensive.
iter_content(chunk_size) will call raw.stream(chunk_size), which
will read chunk_size bytes at a time from the streaming response body.
Setting this greatly reduced the CPU usage when reading a busy stream.

To compare, run https://gist.github.com/ottomata/4f91031112b274826a444444a9af009a
before and after this change, and compare CPU usage of the python process.

See also https://github.com/huggle/XMLRCS/issues/1#issuecomment-288371176 and comments below.