### PR TITLE
Declare and enforce that data must be text.

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -96,6 +96,7 @@ class Event(object):
     sse_line_pattern = re.compile('(?P<name>[^:]*):?( ?(?P<value>.*))?')
 
     def __init__(self, data='', event='message', id=None, retry=None):
+        assert isinstance(data, six.string_types), "Data must be text"
         self.data = data
         self.event = event
         self.id = id


### PR DESCRIPTION
As discovered in #13, bytes aren't allowed for the `data` parameter to `Event`. This PR makes that expectation explicit.