### PR TITLE
Catch http.client.IncompleteRead

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -6,6 +6,7 @@ import warnings
 import six
 
 import requests
+import http
 
 
 # Technically, we should support streams that mix line endings.  This regex,
@@ -67,7 +68,8 @@ class SSEClient(object):
                     raise EOFError()
                 self.buf += decoder.decode(next_chunk)
 
-            except (StopIteration, requests.RequestException, EOFError) as e:
+            except (StopIteration, requests.RequestException, EOFError, http.client.IncompleteRead) as e:
+                print(e)
                 time.sleep(self.retry / 1000.0)
                 self._connect()
 


### PR DESCRIPTION
Thanks for this great library which works well for me, with one exception (pun intended): in my application I frequently get a `http.client.IncompleteRead` that is [thrown by urllib3](https://github.com/urllib3/urllib3/blob/master/src/urllib3/response.py#L605). By adding this exception to the `try ... except` in the iterator, it runs stable again.