### PR TITLE
Support short reads of message chunks (fix #8)

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -46,11 +46,27 @@ class SSEClient(object):
         # Use session if set.  Otherwise fall back to requests module.
         requester = self.session or requests
         self.resp = requester.get(self.url, stream=True, **self.requests_kwargs)
-        self.resp_iterator = self.resp.iter_content(chunk_size=self.chunk_size)
+        self.resp_iterator = self.iter_content()
 
         # TODO: Ensure we're handling redirects.  Might also stick the 'origin'
         # attribute on Events like the Javascript spec requires.
         self.resp.raise_for_status()
+
+    def iter_content(self):
+        def generate():
+            while True:
+                if hasattr(self.resp.raw, '_fp'):
+                    chunk = self.resp.raw._fp.fp.read1(self.chunk_size)
+                else:
+                    # _fp is not available, this means that we cannot use short
+                    # reads and this will block until the full chunk size is
+                    # actually read
+                    chunk = self.resp.raw.read(self.chunk_size)
+                if not chunk:
+                    break
+                yield chunk
+
+        return generate()
 
     def _event_complete(self):
         return re.search(end_of_field, self.buf) is not None


### PR DESCRIPTION
I ran into an issue a while back where behavior in sseclient regressed
due to a change in how messages were processed; the new behavior
resulted in chunks of data in the response only being processed 1024
bytes (or whatever the chunk size was set to) at a time. For less-busy
streams, this had a significant impact on message delivery time because
messages would get buffered but never processed until the buffer
completely filled. To work around this, it was possible to use a chunk
size of 1.

The problem turned out to be that http.client.HTTPResponse was not
designed to handle short reads, so each read call blocks until the
entire chunk size was read or the end of the file is hit. To fix this,
this change reimplements the iter_content method from requests so
that it accesses the underlying io.BufferedReader from
http.client.HTTPResponse and calls read1 on it, which will not block as
long as data is already buffered.