### PR TITLE
Revert "Support short reads of message chunks (fix #8)"

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -54,27 +54,11 @@ class SSEClient(object):
         # Use session if set.  Otherwise fall back to requests module.
         requester = self.session or requests
         self.resp = requester.get(self.url, stream=True, **self.requests_kwargs)
-        self.resp_iterator = self.iter_content()
+        self.resp_iterator = self.resp.iter_content(chunk_size=self.chunk_size)
 
         # TODO: Ensure we're handling redirects.  Might also stick the 'origin'
         # attribute on Events like the Javascript spec requires.
         self.resp.raise_for_status()
-
-    def iter_content(self):
-        def generate():
-            while True:
-                if hasattr(self.resp.raw, '_fp'):
-                    chunk = self.resp.raw._fp.fp.read1(self.chunk_size)
-                else:
-                    # _fp is not available, this means that we cannot use short
-                    # reads and this will block until the full chunk size is
-                    # actually read
-                    chunk = self.resp.raw.read(self.chunk_size)
-                if not chunk:
-                    break
-                yield chunk
-
-        return generate()
 
     def _event_complete(self):
         return re.search(end_of_field, self.buf) is not None


### PR DESCRIPTION
PR20 was inappropriate because it depends on teh underlying requests
package. I didn't found any corresponding "self.resp.raw._fp.fp.read1"
implementations in my tests environment neither in PY 2.7 or in PY 3.
I only found fp.fp.readline().

This patch breaks our library and we went back to 0.0.22 therefore.
in https://gerrit.wikimedia.org/r/#/c/pywikibot/core/+/498452/

btw _fp is private and shouldn't be used by used outside of it

This reverts commit 8585bac65841c0ba9f6b79d59eb77c438abac86d.

See issue #22 and https://phabricator.wikimedia.org/T219024

Change-Id: I776bdf7c86ed733ad3170c4aa7454e7b1d8ca0a7