### PR TITLE
Check all attributes before using short reads

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -63,7 +63,9 @@ class SSEClient(object):
     def iter_content(self):
         def generate():
             while True:
-                if hasattr(self.resp.raw, '_fp'):
+                if hasattr(self.resp.raw, '_fp') and \
+                        hasattr(self.resp.raw._fp, 'fp') and \
+                        hasattr(self.resp.raw._fp.fp, 'read1'):
                     chunk = self.resp.raw._fp.fp.read1(self.chunk_size)
                 else:
                     # _fp is not available, this means that we cannot use short


### PR DESCRIPTION
Fixes #22 and #23 which were identified by regressed tests in a downstream project. Apparently `read1` is not available in Python versions prior to 3.5.