### PR TITLE
Fall back to read() method if read1() attribute is not available

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -63,7 +63,8 @@ class SSEClient(object):
     def iter_content(self):
         def generate():
             while True:
-                if hasattr(self.resp.raw, '_fp'):
+                if (hasattr(self.resp.raw, '_fp') and
+                   hasattr(self.resp.raw._fp.fp, 'read1')):
                     chunk = self.resp.raw._fp.fp.read1(self.chunk_size)
                 else:
                     # _fp is not available, this means that we cannot use short


### PR DESCRIPTION
This pull request fixes regression introduced in #21 (8585bac65841c0ba9f6b79d59eb77c438abac86d).

After upgrading to the latest version our code started failing with the following error:

```bash
'_fileobject' object has no attribute 'read1'
```

This seems to consistently happen under Python 2.7.x using sseclient 0.0.23.