### PR TITLE
[tests] enable Python 3.7 tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,22 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
 install:
   - pip install .
   - yes | pip uninstall pytest
   - pip install pytest>=3.0.4
 script:
     py.test
+
+matrix:
+  include:
+    - python: '3.7'
+      dist: xenial
+      sudo: required
+    - python: '3.8-dev'
+      dist: xenial
+      sudo: required
+  allow_failures:
+    - python: '3.8-dev'
+      dist: xenial
+      sudo: required


### PR DESCRIPTION
Also enable Python 3.8-dev tests which are allowed to fail

Change-Id: Iec327d28eda12a41df46713b60e75e6f497adf47