### PR TITLE
Save unicode decoder state (fixes #38)

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -55,6 +55,8 @@ class SSEClient(object):
         requester = self.session or requests
         self.resp = requester.get(self.url, stream=True, **self.requests_kwargs)
         self.resp_iterator = self.iter_content()
+        self.decoder = codecs.getincrementaldecoder(
+            self.resp.encoding)(errors='replace')
 
         # TODO: Ensure we're handling redirects.  Might also stick the 'origin'
         # attribute on Events like the Javascript spec requires.
@@ -85,14 +87,12 @@ class SSEClient(object):
         return self
 
     def __next__(self):
-        decoder = codecs.getincrementaldecoder(
-            self.resp.encoding)(errors='replace')
         while not self._event_complete():
             try:
                 next_chunk = next(self.resp_iterator)
                 if not next_chunk:
                     raise EOFError()
-                self.buf += decoder.decode(next_chunk)
+                self.buf += self.decoder.decode(next_chunk)
 
             except (StopIteration, requests.RequestException, EOFError, six.moves.http_client.IncompleteRead) as e:
                 print(e)

--- a/test_sseclient.py
+++ b/test_sseclient.py
@@ -213,6 +213,7 @@ def test_client_sends_cookies():
     s.cookies = RequestsCookieJar()
     s.cookies['foo'] = 'bar'
     with mock.patch('sseclient.requests.Session.send') as m:
+        m.return_value.encoding = "utf-8"
         sseclient.SSEClient('http://blah.com', session=s)
         prepared_request = m.call_args[0][0]
         assert prepared_request.headers['Cookie'] == 'foo=bar'

--- a/test_sseclient.py
+++ b/test_sseclient.py
@@ -221,9 +221,9 @@ def test_client_sends_cookies():
 @pytest.fixture
 def unicode_multibyte_responses(monkeypatch):
     content = join_events(
-        E(data=u'ööööööööööööööööööööööööööööööööööööööööööööööööööööööööö', id=u'first', retry=u'2000', event=u'blah'),
-        E(data=u'äääääääääääääääääääääääääääääääääääääääääääääääääääääääää', id=u'second', retry=u'4000', event=u'blerg'),
-        E(data=u'üüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüü', id=u'third'),
+        E(data='ööööööööööööööööööööööööööööööööööööööööööööööööööööööööö', id='first', retry='2000', event='blah'),
+        E(data='äääääääääääääääääääääääääääääääääääääääääääääääääääääääää', id='second', retry='4000', event='blerg'),
+        E(data='üüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüü', id='third'),
     )
     fake_get = mock.Mock(return_value=FakeResponse(200, content))
     monkeypatch.setattr(requests, 'get', fake_get)
@@ -238,9 +238,9 @@ def unicode_multibyte_responses(monkeypatch):
 @pytest.mark.usefixtures("unicode_multibyte_responses")
 def test_multiple_messages():
     c = sseclient.SSEClient('http://blah.com',chunk_size=51)
-    assert next(c).data == u'ööööööööööööööööööööööööööööööööööööööööööööööööööööööööö'
-    assert next(c).data == u'äääääääääääääääääääääääääääääääääääääääääääääääääääääääää'
-    assert next(c).data == u'üüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüü'
+    assert next(c).data == 'ööööööööööööööööööööööööööööööööööööööööööööööööööööööööö'
+    assert next(c).data == 'äääääääääääääääääääääääääääääääääääääääääääääääääääääääää'
+    assert next(c).data == 'üüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüüü'
 
 def test_event_stream():
     """Check whether event.data can be loaded."""


### PR DESCRIPTION
Save the decoder in an instance attribute so its state is save for the next iterator call.

Test cases.