### PR TITLE
Fix Issue #47: using Response.apparent_encoding when Response.encoding is None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ pytest_runner = ['pytest_runner>=2.1'] if needs_pytest else []
 
 setup(
     name='sseclient',
-    version='0.0.26',
+    version='0.0.27',
     author='Brent Tubbs',
     author_email='brent.tubbs@gmail.com',
     py_modules=['sseclient'],

--- a/sseclient.py
+++ b/sseclient.py
@@ -14,7 +14,7 @@ import six
 
 import requests
 
-__version__ = '0.0.26'
+__version__ = '0.0.27'
 
 # Technically, we should support streams that mix line endings.  This regex,
 # however, assumes that a system will provide consistent line endings.
@@ -55,8 +55,8 @@ class SSEClient(object):
         requester = self.session or requests
         self.resp = requester.get(self.url, stream=True, **self.requests_kwargs)
         self.resp_iterator = self.iter_content()
-        self.decoder = codecs.getincrementaldecoder(
-            self.resp.encoding)(errors='replace')
+        encoding = self.resp.encoding or self.resp.apparent_encoding
+        self.decoder = codecs.getincrementaldecoder(encoding)(errors='replace')
 
         # TODO: Ensure we're handling redirects.  Might also stick the 'origin'
         # attribute on Events like the Javascript spec requires.

--- a/test_sseclient.py
+++ b/test_sseclient.py
@@ -73,9 +73,10 @@ def test_eols():
 
 
 class FakeResponse(object):
-    def __init__(self, status_code, content, headers=None):
+    def __init__(self, status_code, content, headers=None, encoding="utf-8"):
         self.status_code = status_code
-        self.encoding = "utf-8"
+        self.encoding = encoding
+        self.apparent_encoding = "utf-8"
         if not isinstance(content, six.text_type):
             content = content.decode("utf-8")
         self.stream = content
@@ -95,9 +96,10 @@ def join_events(*events):
 
 
 # Tests of parsing a multi event stream
-def test_last_id_remembered(monkeypatch):
+@pytest.mark.parametrize("encoding", ["utf-8", None])
+def test_last_id_remembered(monkeypatch, encoding):
     content = 'data: message 1\nid: abcdef\n\ndata: message 2\n\n'
-    fake_get = mock.Mock(return_value=FakeResponse(200, content))
+    fake_get = mock.Mock(return_value=FakeResponse(200, content, encoding=encoding))
     monkeypatch.setattr(requests, 'get', fake_get)
 
     c = sseclient.SSEClient('http://blah.com')


### PR DESCRIPTION
Hi,

This is a proposed fix to Issue #47.
If the response's [encoding](https://requests.readthedocs.io/en/master/api/#requests.Response.encoding) is None, it calls the property [apparent_encoding](https://requests.readthedocs.io/en/master/api/#requests.Response.apparent_encoding) which relies on the chardet library to infer the encoding from the content of the response.

Cyprien