### PR TITLE
Added ProtocolError to retry errors

### DIFF
--- a/sseclient.py
+++ b/sseclient.py
@@ -8,11 +8,11 @@ from __future__ import unicode_literals
 import codecs
 import re
 import time
+import urllib3
 import warnings
 
-import six
-
 import requests
+import six
 
 __version__ = '0.0.27'
 
@@ -94,7 +94,13 @@ class SSEClient(object):
                     raise EOFError()
                 self.buf += self.decoder.decode(next_chunk)
 
-            except (StopIteration, requests.RequestException, EOFError, six.moves.http_client.IncompleteRead) as e:
+            except (
+                EOFError,
+                requests.RequestException,
+                six.moves.http_client.IncompleteRead,
+                StopIteration,
+                urllib3.exceptions.ProtocolError,
+            ) as e:
                 print(e)
                 time.sleep(self.retry / 1000.0)
                 self._connect()


### PR DESCRIPTION
This is a fix for: https://github.com/btubbs/sseclient/issues/52#issue-721507381

### Current Behavior

The sseclient do not currently retry urllib3.ProtocolErrors. ProtocolErrors may be raised when reading raw response data at [self.resp.raw.read](https://github.com/btubbs/sseclient/blob/master/sseclient.py#L76).

As per the urllib3 docs, this error is raised when something **unexpected** happens mid-request/response and the sseclint should therefore try to connect again. 

### Solution

I've simply added the error to the except clause...