### PR TITLE
drop six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author='Brent Tubbs',
     author_email='brent.tubbs@gmail.com',
     py_modules=['sseclient'],
-    install_requires=['requests>=2.9', 'six'],
+    install_requires=['requests>=2.9'],
     tests_require=['pytest', 'backports.unittest_mock'],
     setup_requires=[] + pytest_runner,
     description=(

--- a/sseclient.py
+++ b/sseclient.py
@@ -9,8 +9,7 @@ import codecs
 import re
 import time
 import warnings
-
-import six
+import http.client
 
 import requests
 
@@ -96,7 +95,7 @@ class SSEClient(object):
                         raise EOFError()
                     self.buf += self.decoder.decode(next_chunk)
 
-                except (StopIteration, requests.RequestException, EOFError, six.moves.http_client.IncompleteRead) as e:
+                except (StopIteration, requests.RequestException, EOFError, http.client.IncompleteRead) as e:
                     print(e)
                     time.sleep(self.retry / 1000.0)
                     self._connect()
@@ -130,16 +129,13 @@ class SSEClient(object):
                 return msg
        
 
-    if six.PY2:
-        next = __next__
-
 
 class Event(object):
 
     sse_line_pattern = re.compile('(?P<name>[^:]*):?( ?(?P<value>.*))?')
 
     def __init__(self, data='', event='message', id=None, retry=None):
-        assert isinstance(data, six.string_types), "Data must be text"
+        assert isinstance(data, str), "Data must be text"
         self.data = data
         self.event = event
         self.id = id

--- a/test_sseclient.py
+++ b/test_sseclient.py
@@ -15,7 +15,6 @@ except ImportError:
 
 import pytest
 import requests
-import six
 from requests.cookies import RequestsCookieJar
 
 import sseclient
@@ -88,7 +87,7 @@ class FakeResponse(object):
         self.status_code = status_code
         self.encoding = encoding
         self.apparent_encoding = "utf-8"
-        if not isinstance(content, six.text_type):
+        if not isinstance(content, str):
             content = content.decode("utf-8")
         self.stream = content
         self.headers = headers or None


### PR DESCRIPTION
As all the Python world now works on Python 3, I assume that most of the consumers of this library have dropped Python 2. So six is no longer needed.