### PR TITLE
Update gitignore to ignore .idea, .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@
 /.pytest_cache/
 sseclient.egg-info/
 build
+.idea/
+.DS_Store
 dist


### PR DESCRIPTION
We should ignore .idea (generated by JetBrains IDEs like PyCharm) and .DS_Store (generated by Macs).